### PR TITLE
Update Quick Start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ corepack prepare yarn@4.6.0 --activate
 
 # Install dependencies
 yarn install
+# Ensure this completes without errors before running `yarn build` or `yarn postinstall`
+
+# If native electron dependencies fail to build run:
+# yarn postinstall
+
+# Optionally verify installation
+# yarn preflight
 
 # Start development server
 yarn dev

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "generate:icons": "electron-icon-builder --input=./build/logo.png --output=build",
     "analyze:renderer": "VISUALIZER_RENDERER=true yarn build",
     "analyze:main": "VISUALIZER_MAIN=true yarn build",
+    "preflight": "node scripts/preflight.js",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",

--- a/scripts/preflight.js
+++ b/scripts/preflight.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const nodeModulesPath = path.join(__dirname, '..', 'node_modules');
+if (!fs.existsSync(nodeModulesPath)) {
+  console.warn('node_modules directory not found. Run "yarn install" first.');
+  process.exitCode = 1;
+} else {
+  console.log('node_modules present.');
+}


### PR DESCRIPTION
## Summary
- clarify that `yarn install` must finish before building
- mention that `yarn postinstall` might be needed for electron deps
- add a `preflight` script that warns when `node_modules` is missing

## Testing
- `node scripts/preflight.js`

------
https://chatgpt.com/codex/tasks/task_b_68472ad41ab08332a8b52a07eca991e7