### PR TITLE
Add build:current_os script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:linux": "powershell.exe -Command \"& { dotenv | Out-Null; npm run build; yarn copy-resources; electron-builder --linux --x64 --arm64 }\"",
     "build:linux:arm64": "powershell.exe -Command \"& { dotenv | Out-Null; npm run build; yarn copy-resources; electron-builder --linux --arm64 }\"",
     "build:linux:x64": "powershell.exe -Command \"& { dotenv | Out-Null; npm run build; yarn copy-resources; electron-builder --linux --x64 }\"",
+    "build:current_os": "node scripts/build-current-os.js",
     "build:npm": "node scripts/build-npm.js",
     "release": "node scripts/version.js",
     "publish": "powershell.exe -Command \"& { dotenv | Out-Null; yarn build:check; yarn release patch push }\"",

--- a/scripts/build-current-os.js
+++ b/scripts/build-current-os.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process')
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit', shell: true })
+}
+
+switch (process.platform) {
+  case 'win32':
+    run('yarn build:win')
+    break
+  case 'darwin':
+    run('yarn build:mac')
+    break
+  case 'linux':
+    run('yarn build:linux')
+    break
+  default:
+    console.error(`Unsupported platform: ${process.platform}`)
+    process.exit(1)
+}


### PR DESCRIPTION
## Summary
- create script to map current OS to platform build commands
- wire `build:current_os` in `package.json`

## Testing
- `yarn install` *(fails: lockfile would have been modified)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_68472ad494a88332b4da9eeeb3dc33a6