### PR TITLE
Fix publish artifacts script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:npm": "node scripts/build-npm.js",
     "release": "node scripts/version.js",
     "publish": "powershell.exe -Command \"& { dotenv | Out-Null; yarn build:check; yarn release patch push }\"",
-    "pulish:artifacts": "cd packages/artifacts; npm publish; cd -",
+    "publish:artifacts": "cd packages/artifacts; npm publish; cd -",
     "generate:agents": "node scripts/generate-agents.js",
     "generate:icons": "electron-icon-builder --input=./build/logo.png --output=build",
     "analyze:renderer": "VISUALIZER_RENDERER=true yarn build",


### PR DESCRIPTION
## Summary
- fix `publish:artifacts` script name in `package.json`

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_68472ad5537c83328399910de2e7b1cf