### PR TITLE
Fix duplicated dev guide content

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -27,30 +27,6 @@ This document explains how to set up your environment for TykoTech Fork developm
 
 Run `yarn install` to fetch dependencies. If it fails with network errors, revisit the proxy settings above.
 
-## Test
-
-After installation you can run the test suite:
-
-# TykoTech Fork Development Guide
-
-This document describes how to set up a development environment for TykoTech Fork.
-
-## Requirements
-
-- **Node.js** v20 or newer
-- **Yarn** v4.6.0 (managed via Corepack)
-
-## Setup
-
-Run the following commands to prepare your environment:
-
-```bash
-corepack enable
-corepack prepare yarn@4.6.0 --activate
-# Install dependencies
-yarn install
-```
-
 ## Starting the App in Development Mode
 
 ```bash


### PR DESCRIPTION
## Summary
- remove duplicate heading and setup text from dev docs
- describe starting dev mode after installing dependencies
- keep build and test sections in order

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_68472ad5c5a08332acd3d89fe964d274