### PR TITLE
Add native deps install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ corepack prepare yarn@4.6.0 --activate
 # Install dependencies
 yarn install
 
+# Install native Electron dependencies
+yarn postinstall
+
 # Start development server
 yarn dev
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ If you prefer to build the application yourself:
 corepack enable
 corepack prepare yarn@4.6.0 --activate
 yarn install
+# Install native Electron dependencies
+yarn postinstall
 # Build for your current platform
 yarn build:current_os
 ```


### PR DESCRIPTION
## Summary
- mention running `yarn postinstall` after installing packages
- note same step in docs/README

## Testing
- `yarn install` *(fails: Couldn't finish fetching packages)*

------
https://chatgpt.com/codex/tasks/task_b_68472ad6d0c883329162a8e56ec1746d