### PR TITLE
Add postinstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ corepack prepare yarn@4.6.0 --activate
 
 # Install dependencies
 yarn install
+# Install native Electron dependencies
+yarn postinstall
 
 # Start development server
 yarn dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ If you prefer to build the application yourself:
 corepack enable
 corepack prepare yarn@4.6.0 --activate
 yarn install
+# Install native Electron dependencies
+yarn postinstall
 # Build for your current platform
 yarn build:current_os
 ```


### PR DESCRIPTION
## Summary
- update Quick Start docs with instructions to run `yarn postinstall`
- mention the same step in docs/README

## Testing
- `npm test` *(fails: powershell.exe not found)*

------
https://chatgpt.com/codex/tasks/task_b_68472fddc24c8332b58ebc32603bed8a